### PR TITLE
Update pdfstring.py to correctly decode using python 3.5

### DIFF
--- a/pdfrw/objects/pdfstring.py
+++ b/pdfrw/objects/pdfstring.py
@@ -110,7 +110,7 @@ class PdfString(str):
             # escape, the backslash is ignored.
             return m.group(1)
 
-        return self.unescape_re.sub(handle_escape, bytearray(self[1:-1]))
+        return self.unescape_re.sub(handle_escape,  bytes(bytearray(self[1:-1], encoding='pdfdocencoding'))
 
     def decode_bytes(self, bytestr):
         if bytestr[:2] == codecs.BOM_UTF16_BE:

--- a/pdfrw/objects/pdfstring.py
+++ b/pdfrw/objects/pdfstring.py
@@ -110,7 +110,7 @@ class PdfString(str):
             # escape, the backslash is ignored.
             return m.group(1)
 
-        return self.unescape_re.sub(handle_escape,  bytes(bytearray(self[1:-1], encoding='pdfdocencoding'))
+        return self.unescape_re.sub(handle_escape,  bytes(bytearray(self[1:-1], encoding='pdfdocencoding')))
 
     def decode_bytes(self, bytestr):
         if bytestr[:2] == codecs.BOM_UTF16_BE:

--- a/pdfrw/objects/pdfstring.py
+++ b/pdfrw/objects/pdfstring.py
@@ -110,7 +110,7 @@ class PdfString(str):
             # escape, the backslash is ignored.
             return m.group(1)
 
-        return self.unescape_re.sub(handle_escape,  bytes(bytearray(self[1:-1], encoding='pdfdocencoding')))
+        return self.unescape_re.sub(handle_escape, bytes(bytearray(self[1:-1], encoding='pdfdocencoding')))
 
     def decode_bytes(self, bytestr):
         if bytestr[:2] == codecs.BOM_UTF16_BE:


### PR DESCRIPTION
Running tests showed that only python 2.7 would pass here this fixes it for 3.5.
